### PR TITLE
Added possibility to suggest free IPs on local subnet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name='adidnsdump',
+setup(name='scrtdnsdump',
       version='1.3.0',
       description='Active Directory Integrated DNS dumping by any authenticated user',
       license='MIT',
@@ -18,8 +18,8 @@ setup(name='adidnsdump',
       author_email='dirkjan.mollema@fox-it.com',
       url='https://github.com/dirkjanm/adidnsdump',
       packages=['adidnsdump'],
-      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6'],
+      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'scapy', 'netifaces', 'ipaddress'],
       entry_points={
-          'console_scripts': ['adidnsdump=adidnsdump:main']
+          'console_scripts': ['scrtdnsdump=adidnsdump:main']
       }
      )


### PR DESCRIPTION
It can sometimes be very useful to be able to find stale DNS names which point to an IP on the current range in order to "borrow" the IP and profit from an undotted hostname to exploit coercing and NTLM relaying techniques from HTTP to other protocols while having the vicitim send their credentials.
This small addition will iterate through the results from the DNS dump and checks whether any of the IPs are on the current subnet and if they are free by performin an ARPing request.