### PR TITLE
Add support for Kerberos authentication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='adidnsdump',
       author_email='dirkjan@dirkjanm.io',
       url='https://github.com/dirkjanm/adidnsdump',
       packages=['adidnsdump'],
-      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6'],
+      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'gssapi'],
       entry_points={
           'console_scripts': ['adidnsdump=adidnsdump:main']
       }


### PR DESCRIPTION
Add `-k` option for Kerberos authentication. Uses the standard krb5.conf and ccache files.
