### PR TITLE
Fix uncaught Exception

### DIFF
--- a/adidnsdump/dnsdump.py
+++ b/adidnsdump/dnsdump.py
@@ -455,7 +455,7 @@ def main():
                 # Resolve A query
                 try:
                     res = dnsresolver.query('%s.%s.' % (recordname, zone), 'A', tcp=args.dns_tcp, raise_on_no_answer=False)
-                except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.resolver.Timeout, dns.name.EmptyLabel) as e:
+                except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.resolver.Timeout, dns.resolver.NoNameservers, dns.name.EmptyLabel) as e:
                     if args.verbose:
                         print_f(str(e))
                     print_m('Could not resolve node %s (probably no A record assigned to name)' % recordname)


### PR DESCRIPTION
There was an uncaught Exception when all known dns servers answered SERVFAIL:

```
Traceback (most recent call last):
  File "/root/.local/bin/adidnsdump", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/root/.local/share/pipx/venvs/adidnsdump/lib/python3.12/site-packages/adidnsdump/dnsdump.py", line 457, in main
    res = dnsresolver.query('%s.%s.' % (recordname, zone), 'A', tcp=args.dns_tcp, raise_on_no_answer=False)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/adidnsdump/lib/python3.12/site-packages/dns/resolver.py", line 1363, in query
    return self.resolve(
           ^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/adidnsdump/lib/python3.12/site-packages/dns/resolver.py", line 1317, in resolve
    (nameserver, tcp, backoff) = resolution.next_nameserver()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/adidnsdump/lib/python3.12/site-packages/dns/resolver.py", line 764, in next_nameserver
    raise NoNameservers(request=self.request, errors=self.errors)
dns.resolver.NoNameservers: All nameservers failed to answer the query trololo.com. IN A: Server Do53:10.2.1.5@53 answered SERVFAIL; Server Do53:10.2.1.4@53 answered SERVFAIL
```