### PR TITLE
added support for output in `/etc/hosts` format, and added kerberos authentication

### DIFF
--- a/adidnsdump/dnsdump.py
+++ b/adidnsdump/dnsdump.py
@@ -358,6 +358,7 @@ def main():
     parser.add_argument("--dcfilter", action='store_true', help="Use an alternate filter to identify DNS record types")
     parser.add_argument("--sslprotocol", help="SSL version for LDAP connection, can be SSLv23, TLSv1, TLSv1_1 or TLSv1_2")
     parser.add_argument("--outfile", default='records.csv', help="Output file name/path (default: records.csv)")
+    parser.add_argument("--hosts", action='store_true', help="Format output in hosts file style")
 
     args = parser.parse_args()
     #Prompt for password if not set
@@ -500,6 +501,22 @@ def main():
 
             continue
     print_o(f'Found {len(outdata)} records, saving to {args.outfile}')
+    if args.hosts:
+        with codecs.open(args.outfile, 'w', 'utf-8') as outfile:
+            for row in outdata:
+                if row['type'] == 'A':
+                    ip_address = row['value']
+                    hostname = row['name'].upper()
+                    fqdn = f"{hostname}.{zone}"
+                    if hostname == '@': # domain root
+                        outfile.write(f"{ip_address} {zone}")
+                        continue
+                    elif hostname == 'DOMAINDNSZONES': # domain root
+                        continue
+                    else:
+                        outfile.write(f"{ip_address} {fqdn} {hostname}\n")
+        return
+
     with codecs.open(args.outfile, 'w', 'utf-8') as outfile:
         outfile.write('type,name,value\n')
         for row in outdata:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='adidnsdump',
       author_email='dirkjan@dirkjanm.io',
       url='https://github.com/dirkjanm/adidnsdump',
       packages=['adidnsdump'],
-      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6'],
+      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'dnspython', 'gssapi'],
       entry_points={
           'console_scripts': ['adidnsdump=adidnsdump:main']
       }


### PR DESCRIPTION
hey, wanted to save myself some time in future use by allowing the output to be in a nice format to add to `/etc/hosts`, doesn't affect normal functionality.

```
adidnsdump -u 'domain\user' -p 'password' domain.local --hosts --outfile hosts.txt
[-] Connecting to host...
[-] Binding to host
[+] Bind OK
[-] Querying zone for records
[+] Found 12 records, saving to hosts.txt

cat hosts.txt

10.5.10.88     PC1.domain.local             PC1
10.5.10.143    PC2.domain.local             PC2
10.5.10.117    PC3.domain.local             PC3
10.5.10.209    PC4.domain.local             PC4
10.5.10.195    PC5.domain.local             PC5
10.5.10.66     PC6.domain.local             PC6
10.5.10.138    PC7.domain.local             PC7
10.5.10.101    PC8.domain.local             PC8
10.5.10.231    DC.domain.local              DC
10.5.10.231    domain.local
```